### PR TITLE
Update to include supported ActiveMQ broker engine versions

### DIFF
--- a/doc_source/amazon-mq-creating-applying-configurations.md
+++ b/doc_source/amazon-mq-creating-applying-configurations.md
@@ -29,7 +29,7 @@ The following example shows how you can create and apply an Amazon MQ broker con
 
 1. On the **Create configuration** page, in the **Details** section, type the **Configuration name** \(for example, `MyConfiguration`\) and select a **Broker engine** version\.
 **Note**  
-Currently, Amazon MQ supports only `ActiveMQ` broker engine versions `5.15.8`, `5.15.6` and `5.15.0`\.
+Currently, Amazon MQ supports only `ActiveMQ` broker engine versions `5.15.13`, `5.15.12`, `5.15.10`, `5.15.9`, `5.15.8`, `5.15.6` and `5.15.0`\.
 
 1. Choose **Create configuration**\.
 


### PR DESCRIPTION
*Issue #, if available:*
 -No issue-

*Description of changes:*

Amazon MQ supports `ActiveMQ` broker engine versions `5.15.13`, `5.15.12`, `5.15.10`, `5.15.9`, `5.15.8`, `5.15.6` and `5.15.0`.
Source: https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
