### PR TITLE
Correcting the dynamic shovel API request method to PUT

### DIFF
--- a/doc_source/rabbitmq-basic-elements-plugins.md
+++ b/doc_source/rabbitmq-basic-elements-plugins.md
@@ -12,7 +12,7 @@ Amazon MQ supports the [RabbitMQ management plugin](https://www.rabbitmq.com/man
 
 Amazon MQ managed brokers support [RabbitMQ shovel](https://www.rabbitmq.com/shovel.html), allowing you to move messages from queues and exchanges on one broker instance to another\. You can use shovel to connect loosely coupled brokers and distribute messages away from nodes with heavier message loads\.
 
-Amazon MQ managed RabbitMQ brokers support dynamic shovels\. Dynamic shovels are configured using runtime parameters, and can be started and stopped at any time programatically by a client connection\. For example, using the RabbitMQ management API, you can create a `POST` request to the following API endpoint to configure a dynamic shovel\. In the example, `{vhost}` can be replaced by the name of the broker's vhost, and `{name}` replaced by the name of the new dynamic shovel\.
+Amazon MQ managed RabbitMQ brokers support dynamic shovels\. Dynamic shovels are configured using runtime parameters, and can be started and stopped at any time programatically by a client connection\. For example, using the RabbitMQ management API, you can create a `PUT` request to the following API endpoint to configure a dynamic shovel\. In the example, `{vhost}` can be replaced by the name of the broker's vhost, and `{name}` replaced by the name of the new dynamic shovel\.
 
 ```
 /api/parameters/shovel/{vhost}/{name}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Under the `Using HTTP API` heading on the [RabbitMQ Dynamic shovel documentation](https://www.rabbitmq.com/shovel-dynamic.html) it states the request method to add / update a dynamic shovel is a `PUT` not a `POST`

I have also tested this on a Amazon MQ RabbitMQ broker instance to confirm a `PUT` is correct 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
