### PR TITLE
Update getting-started-activemq.md

### DIFF
--- a/doc_source/getting-started-activemq.md
+++ b/doc_source/getting-started-activemq.md
@@ -20,7 +20,7 @@ The first and most common Amazon MQ task is creating a broker\. The following ex
 1. On the **Select deployment and storage** page, in the **Deployment mode and storage type** section, do the following:
 
    1. Choose the **Deployment mode** \(for example, **Active/standby broker**\)\. For more information, see [Broker architecture](amazon-mq-broker-architecture.md)\.
-      + A **Single\-instance broker** is comprised of one broker in one Availability Zone\. The broker communicates with your application and with an Amazon EBS or Amazon EFS storage volume\. For more information, see [Amazon MQ single\-instance broker](single-broker-deployment.md)\.
+      + A **Single\-instance broker** has one broker in one Availability Zone\. The broker communicates with your application and with an Amazon EBS or Amazon EFS storage volume\. For more information, see [Amazon MQ single\-instance broker](single-broker-deployment.md)\.
       + An **Active/standby broker for high availability** is comprised of two brokers in two different Availability Zones, configured in a *redundant pair*\. These brokers communicate synchronously with your application, and with Amazon EFS\. For more information, see [Amazon MQ active/standby broker for high availability](active-standby-broker-deployment.md)\.
       + For more information on the sample blueprints for a network of brokers, see [Sample blueprints](network-of-brokers.md#sample-deployments)\.
 


### PR DESCRIPTION
The authors of The Blue Book of Grammar and Punctuation state that comprised of is never correct because the word comprise by itself already means "composed of".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
