### PR TITLE
Add Broker dimension to list of RMQ Queue Dimensions

### DIFF
--- a/doc_source/security-logging-monitoring-cloudwatch.md
+++ b/doc_source/security-logging-monitoring-cloudwatch.md
@@ -171,3 +171,4 @@ For more information about dimension names, see [Dimension](https://docs.aws.ama
 | --- | --- | 
 | Queue | The name of the queue\. | 
 | VirtualHost | Name of the virtual host\. | 
+| Broker |  The name of the broker\.  | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When exploring CloudWatch metrics "Broker" is one dimension of the Queue metrics for RabbitMQ, this was not listed in the documentation which caused some confusion when settings things up in Grafana

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
