### PR TITLE
Fixed typos in amazon-mq-rabbitmq-pika.md

### DIFF
--- a/doc_source/amazon-mq-rabbitmq-pika.md
+++ b/doc_source/amazon-mq-rabbitmq-pika.md
@@ -60,7 +60,7 @@ To create a Python Pika client base class that defines a constructor and provide
            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
            ssl_context.set_ciphers('ECDHE+AESGCM:!ECDSA')
    
-           url = f"amqps://{rabbitmq_user}:{rabbitmq_password}@{rabbitmq_broker_id}.mq.{region}.amazonaws.com:5671"
+           url = "amqps://{rabbitmq_user}:{rabbitmq_password}@{rabbitmq_broker_id}.mq.{region}.amazonaws.com:5671"
            parameters = pika.URLParameters(url)
            parameters.ssl_options = pika.SSLOptions(context=ssl_context)
    
@@ -82,7 +82,7 @@ To create a Python Pika client base class that defines a constructor and provide
    class BasicMessageSender(BasicPikaClient):
    
        def declare_queue(self, queue_name):
-           print(f"Trying to declare queue({queue_name})...")
+           print("Trying to declare queue({queue_name})...")
            self.channel.queue_declare(queue=queue_name)
    
        def send_message(self, exchange, routing_key, body):
@@ -90,7 +90,7 @@ To create a Python Pika client base class that defines a constructor and provide
            channel.basic_publish(exchange=exchange,
                                  routing_key=routing_key,
                                  body=body)
-           print(f"Sent message. Exchange: {exchange}, Routing Key: {routing_key}, Body: {body}")
+           print("Sent message. Exchange: {exchange}, Routing Key: {routing_key}, Body: {body}")
    
        def close(self):
            self.channel.close()


### PR DESCRIPTION
Removed extra characters from the readme that were causing invalid syntax errors.

*Issue #, if available:*
When running the sample python commands, the code was failing with `SyntaxError: invalid syntax` due to the extra characters.

*Description of changes:*
I removed the extra characters from the sample code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
