### PR TITLE
Fixes typo in `Setting up Amazon MQ` Step 1

### DIFF
--- a/doc_source/amazon-mq-setting-up.md
+++ b/doc_source/amazon-mq-setting-up.md
@@ -12,7 +12,7 @@ Before you can use Amazon MQ, you must complete the following steps\.
 
 To access any AWS service, you must first create an [Amazon Web Services account](https://aws.amazon.com/)\. This is an Amazon account that can use AWS products\. You can use your AWS account to view your activity and usage reports and to manage authentication and access\.
 
-1. Navigate to the [AWS home page](https://aws.amazon.com/), and then choose **Create an Amazon Web Services \]Account**\.
+1. Navigate to the [AWS home page](https://aws.amazon.com/), and then choose **Create an AWS Account**\.
 
 1. Follow the instructions\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The button on the home page reads `Create an AWS Account`. There was also an erroneous right bracket character in the name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
